### PR TITLE
Remove use of old git-foo names

### DIFF
--- a/git-closest-match
+++ b/git-closest-match
@@ -6,7 +6,7 @@ spec=$1
 mode=${2:-diff} # num: number of lines or diff: actual diff/log message?
 range=${3:-30} # 'all' or most recent <num> in current branch?. 'all' can be quite slow
 if [ "$range" = 'all' ]; then
-	all=`git-rev-list --all | awk '/^commit/ {print $NF}'`
+	all=`git rev-list --all | awk '/^commit/ {print $NF}'`
 else
 	all=`git log -n $range | awk '/^commit/ {print $NF}'`
 fi

--- a/git-find-blob
+++ b/git-find-blob
@@ -2,10 +2,10 @@
 
 filename=$1
 
-want=$(git-hash-object "$filename")
+want=$(git hash-object "$filename")
 
-git-rev-list --since="6 months ago" HEAD | while read commit ; do
-    git-ls-tree -r $commit | while read perm type hash filename; do
+git rev-list --since="6 months ago" HEAD | while read commit ; do
+    git ls-tree -r $commit | while read perm type hash filename; do
         if test "$want" = "$hash"; then
             echo matched $filename in commit $commit
         fi

--- a/git-sh
+++ b/git-sh
@@ -315,7 +315,7 @@ __git_heads ()
 		done
 		return
 	fi
-	for i in $(git-ls-remote "$1" 2>/dev/null); do
+	for i in $(git ls-remote "$1" 2>/dev/null); do
 		case "$is_hash,$i" in
 		y,*) is_hash=n ;;
 		n,*^{}) is_hash=y ;;
@@ -336,7 +336,7 @@ __git_tags ()
 		done
 		return
 	fi
-	for i in $(git-ls-remote "$1" 2>/dev/null); do
+	for i in $(git ls-remote "$1" 2>/dev/null); do
 		case "$is_hash,$i" in
 		y,*) is_hash=n ;;
 		n,*^{}) is_hash=y ;;
@@ -363,7 +363,7 @@ __git_refs ()
 		done
 		return
 	fi
-	for i in $(git-ls-remote "$dir" 2>/dev/null); do
+	for i in $(git ls-remote "$dir" 2>/dev/null); do
 		case "$is_hash,$i" in
 		y,*) is_hash=n ;;
 		n,*^{}) is_hash=y ;;
@@ -386,7 +386,7 @@ __git_refs2 ()
 __git_refs_remotes ()
 {
 	local cmd i is_hash=y
-	for i in $(git-ls-remote "$1" 2>/dev/null); do
+	for i in $(git ls-remote "$1" 2>/dev/null); do
 		case "$is_hash,$i" in
 		n,refs/heads/*)
 			is_hash=y


### PR DESCRIPTION
git-closest-match, git-find-blob and git-sh die with errors like "command not found: git-rev-list" as the name is "git rev-list".

This patch uses the new names.
