### PR TITLE
Retain space after ---, +++ and add TAB before (revision 0)

### DIFF
--- a/git-svn-diff
+++ b/git-svn-diff
@@ -21,6 +21,9 @@
 #	- Remove EOL whitespaces.
 #       - 2011-12-27 Incorporate fixes by https://github.com/nfloyd
 #         from the Gist comment 2011-07-31 https://gist.github.com/946727
+#
+#   <javabrett>
+#   - Retain space after leading --- and +++, add TAB before (revision 0)
 
 # Get the tracking branch (if we're on a branch)
 
@@ -49,7 +52,7 @@ REV=$(git svn info |
 git diff \
     --no-prefix $(git rev-list --date-order --max-count=1 $TRACKING_BRANCH) \
     "$@" |
-sed -e "/--- \/dev\/null/{ N; s|^--- /dev/null\n+++ \(.*\)|---\1(revision 0)\n+++\1(revision 0)|;}" \
+sed -e "/--- \/dev\/null/{ N; s|^--- /dev/null\n+++ \(.*\)|--- \1\t(revision 0)\n+++ \1\t(revision 0)|;}" \
     -e "s/^--- .*/&     (revision $REV)/" \
     -e "s/^+++ .*/&     (working copy)/" \
     -e "s/^diff --git [^[:space:]]*/Index:/" \


### PR DESCRIPTION
I had some trouble getting Review Board to accept a patch consisting of a single new file.  I compared the patch TortoiseSVN created, and found that the critical differences were:

1) need the space after --- and +++
2) Need some whitespace before (revision 0) - Tortoise seems to insert a TAB

With these changes, Review Board accepts the patch.

I'm not sure whether discarding the space after --- and +++ is intentional.
