### PR TITLE
git-unpack fixes, improvement

### DIFF
--- a/git-unpack
+++ b/git-unpack
@@ -1,12 +1,17 @@
 #!/bin/sh
 
-mkdir /tmp/tmpgit.$$
-GIT_DIR=/tmp/tmpgit.$$ git init
+if [ -f .git/objects/pack/*.pack ]; then
+  mkdir /tmp/tmpgit.$$
+  GIT_DIR=/tmp/tmpgit.$$ git init
 
-for pack in .git/objects/pack/*.pack; do
+  for pack in .git/objects/pack/*.pack; do
     GIT_DIR=/tmp/tmpgit.$$ git unpack-objects < $pack
-done
+  done
 
-rsync -a --info=PROGRESS2 --delete /tmp/tmpgit.$$/objects/ .git/objects/
+  rsync -a --info=PROGRESS2 --delete /tmp/tmpgit.$$/objects/ .git/objects/
 
-rm -fr /tmp/tmpgit.$$
+  rm -fr /tmp/tmpgit.$$
+else
+  echo "No packs to unpack"
+  exit 1
+fi

--- a/git-unpack
+++ b/git-unpack
@@ -6,6 +6,10 @@ if [ -f .git/objects/pack/*.pack ]; then
 
   for pack in .git/objects/pack/*.pack; do
     GIT_DIR=/tmp/tmpgit.$$ git unpack-objects < $pack
+    if [ $? -ne 0 ]; then
+      echo "Unpack of $pack failed, aborting"
+      exit 1
+    fi
   done
 
   rsync -a --info=PROGRESS2 --delete /tmp/tmpgit.$$/objects/ .git/objects/

--- a/git-unpack
+++ b/git-unpack
@@ -7,6 +7,6 @@ for pack in .git/objects/pack/*.pack; do
     GIT_DIR=/tmp/tmpgit.$$ git unpack-objects < $pack
 done
 
-rsync -a --delete /tmp/tmpgit.$$/objects/ .git/objects/
+rsync -a --info=PROGRESS2 --delete /tmp/tmpgit.$$/objects/ .git/objects/
 
 rm -fr /tmp/tmpgit.$$


### PR DESCRIPTION
Fixes and an improvement for git-unpack.  I found this script to be inherently unsafe (due to the rsync --delete): I offer these improvements to it for now, but I think there is a better and safer overall approach, which I may also publish.

I found a problem whereby this script is not idempotent, and if run twice, or run on a repo without any packs, will result in loss of your object store when the rsync --delete runs.  I added a check so that nothing runs if there are no packs present.

Additionally, if any single git-unpack fails, the whole script should fail, avoiding the rsync --delete in that case.  Added a check and fail-fast.

Finally, since git-unpack by-default reports on its progress (you can suppress this but we don't here), we should have rsync do the same with --info=PROGRESS2, so progress is reported for the rsync phase on large repos.

