### PR TITLE
Added git-discover-large-blobs

### DIFF
--- a/git-discover-large-blobs
+++ b/git-discover-large-blobs
@@ -1,0 +1,32 @@
+#!/bin/bash
+#set -x 
+
+# Shows you the largest objects in your repo's pack file.
+#
+# @see http://stubbisms.wordpress.com/2009/07/10/git-script-to-show-largest-pack-objects-and-trim-your-waist-line/
+# @author Antony Stubbs
+
+# set the internal field separator to line break, so that we can iterate easily over the verify-pack output
+IFS=$'\n';
+
+# list all objects including their size, sort by size, take top 10
+objects=`git verify-pack -v .git/objects/pack/pack-*.idx | grep -v chain | sort -k3nr | head`
+
+echo "All sizes are in kB's. The pack column is the size of the object, compressed, inside the pack file."
+
+output="size,pack,SHA,location"
+for y in $objects
+do
+	# extract the size in bytes
+	size=$((`echo $y | cut -f 5 -d ' '`/1024))
+	# extract the compressed size in bytes
+	compressedSize=$((`echo $y | cut -f 6 -d ' '`/1024))
+	# extract the SHA
+	sha=`echo $y | cut -f 1 -d ' '`
+	# find the objects location in the repository tree
+	other=`git rev-list --all --objects | grep $sha`
+	#lineBreak=`echo -e "\n"`
+	output="${output}\n${size},${compressedSize},${other}"
+done
+
+echo -e $output | column -t -s ', '


### PR DESCRIPTION
```sh
➜  your-repo git:(master) ✗ git-discover-large-blobs                 
All sizes are in kB's. The pack column is the size of the object, compressed, inside the pack file.
size   pack  SHA                                       location
11140  1014  cf840b3a96e9b1f2e9db48f0727dea1a37300e35  some-dir/some.sql
7548   985   5adab8bd44a3313283ae2f0d6fdd256ac45cf336  some-dir/some.log
6834   6120  0f5412639b7a33c7b31c87280e6d459d3dd7a9e6  some-dir/some.jar
6010   5392  4468302efe9c9e9f149dbe2f9bf63d600c6e3cdc  some-dir/some2.jar
5824   5800  6cfd732c40966f2867a2ecc5e9d9694bf4f44ba2  some-dir/some.zip
3779   919   42042b7c86f3767bf7821e9f93f466d4e2219447  
......

```