### PR TITLE
Added support for non-empty git-svn prefix

### DIFF
--- a/git-svn-diff
+++ b/git-svn-diff
@@ -25,6 +25,10 @@
 #	<javabrett>
 #	- Retain space after leading --- and +++, add TAB before (revision 0)
 #	- Use \t instead of spaces before (revision $REV) and (working copy)
+#
+#	<javabrett>
+#	- Added support for non-empty git-svn prefix, important now that the
+#	- default --prefix is "origin/" in Git 2.0+.
 
 # Get the tracking branch (if we're on a branch)
 
@@ -38,6 +42,11 @@ case "$TRACKING_BRANCH" in
     URL*)
         TRACKING_BRANCH=$(git config --get svn-remote.svn.fetch |
                           sed -e 's,.*:refs/remotes/,,')
+        ;;
+    *)
+        # GIT_SVN_PREFIX will be origin/ by-default in Git 2.0 or later, or ""
+        GIT_SVN_PREFIX=$(git config --get svn-remote.svn.branches | sed -e 's,.*:refs/remotes/\(.*\)\*$,\1,')
+        TRACKING_BRANCH=${GIT_SVN_PREFIX}${TRACKING_BRANCH}
         ;;
 esac
 


### PR DESCRIPTION
Prior to Git 2.0, git-svn init/clone operations used an empty --prefix by-default.  In 2.0, the default prefix is changed to "origin/".  This is for good reason - it avoids the non-standard, non-prefixed branch-names previously-created by git-svn when importing remote branches.

The git-svn-diff script, when working on non-trunk (i.e. a branch under /branches) made the assumption that remote branch-names were non-prefixed, e.g. "my-branch" instead of "origin/my-branch" when looking for the current commit.

This commit adds support for discovering and using the git-svn prefix.  It should work with both Git <2.0 and >=2.0, and with empty and non-empty prefixes.