### PR TITLE
Show contribution from all authors

### DIFF
--- a/git-contr
+++ b/git-contr
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+filePath=$1
+
+git blame --line-porcelain -C $filePath | sed -n 's/^author //p' |
+sort | uniq -c | sort -rn


### PR DESCRIPTION
The SHELL script should be modified to list
all authors with contribution lines of code
for specified file.

* original author of each line of code in specified file shown
* USAGE: git contr filePath/fileName

Signed-off-by: Naveen Karippai
<naveenranjankarippai@gmail.com>