### PR TITLE
chore: Fix most shell deprecations

### DIFF
--- a/git-all-commits
+++ b/git-all-commits
@@ -2,9 +2,9 @@
 
 find .git/objects -type f | \
 while read file; do
-    if echo $file | egrep -q '\.idx$'; then
+    if echo $file | grep -Eq '\.idx$'; then
         git show-index < $file | awk '{print $2}'
-    elif echo $file | egrep -q '[0-9a-f]{38}$'; then
+    elif echo $file | grep -Eq '[0-9a-f]{38}$'; then
         echo $(basename $(dirname $file))$(basename $file)
     fi
 done | \

--- a/git-all-objects
+++ b/git-all-objects
@@ -2,7 +2,7 @@
 set -e
 shopt -s nullglob extglob
 
-cd "`git rev-parse --git-path objects`"
+cd "$(git rev-parse --git-path objects)"
 
 # packed objects
 for p in pack/pack-*([0-9a-f]).idx ; do

--- a/git-apply-url
+++ b/git-apply-url
@@ -40,9 +40,9 @@ if [[ ! $URL ]]; then
   error $0 URL
 fi
 
-if [[ -x $(which curl) && $(curl -V | grep https) ]]; then
+if [ -x $(command -v curl) ] && [ $(curl -V | grep https) ]; then
   fetch="curl -s"
-elif [[ -x $(which wget) ]]; then
+elif [ -x $(command -v wget) ]; then
   fetch="wget -O - -q --no-check-certificate"
 else
   error need curl or wget

--- a/git-branch-done
+++ b/git-branch-done
@@ -11,6 +11,6 @@ else
 fi
 
 # get  current branch - typically topic branch like taskXXXX, bugXXXX, ...
-cb=`git rev-parse --abbrev-ref HEAD`
+cb=$(git rev-parse --abbrev-ref HEAD)
 # no fast forward merge from current branch to destination branch
 git checkout $DST_BRANCH && git merge --no-ff $cb && git branch -d $cb

--- a/git-changebar
+++ b/git-changebar
@@ -37,25 +37,25 @@ $1
       OUT="${FILE%.tex}.diff.tex"
       cp "$FILE" "$OUT"
 
-      docstart=`grep -n 'begin{document}' "$FILE" | cut -d: -f1`
+      docstart=$(grep -n 'begin{document}' "$FILE" | cut -d: -f1)
 
-      for i in `GIT_DIFF_OPTS=-u0 git diff "$REV" "$FILE" | 
-                sed -n '/^@@/s/@@ -[0-9,]* +\([0-9,]*\).*/\1/p'`
+      for i in $(GIT_DIFF_OPTS=-u0 git diff "$REV" "$FILE" | 
+                sed -n '/^@@/s/@@ -[0-9,]* +\([0-9,]*\).*/\1/p')
       do
-         start=`cut -d, -f1 <<@
+         start=$(cut -d, -f1 <<@
 $i
 @
-`
+)
          if [ "$start" -gt "$docstart" ]
          then
             if grep ',' >/dev/null <<@
 $i
 @
             then
-               diff=`cut -d, -f2 <<@ 
+               diff=$(cut -d, -f2 <<@ 
 $i
 @
-`
+)
             else
                diff=0
             fi

--- a/git-clone.sh
+++ b/git-clone.sh
@@ -3,7 +3,7 @@
 # this script clones a repository, including all its remote branches
 # Author: julianromera
 
-GIT=`which git`
+GIT=$(command -v git)
 
 if [ "x$1" = "x" -o "x$2" = "x" ];then
   echo "use: $0 <git_repository_to_clone> <directory>"
@@ -23,7 +23,7 @@ function clone {
   
   $GIT pull --all
   
-  for remote in `$GIT branch -r | grep -v \>`; do
+  for remote in $($GIT branch -r | grep -v \>); do
      $GIT branch --track ${remote#origin/} $remote;
   done
 }

--- a/git-closest-match
+++ b/git-closest-match
@@ -6,16 +6,16 @@ spec=$1
 mode=${2:-diff} # num: number of lines or diff: actual diff/log message?
 range=${3:-30} # 'all' or most recent <num> in current branch?. 'all' can be quite slow
 if [ "$range" = 'all' ]; then
-	all=`git rev-list --all | awk '/^commit/ {print $NF}'`
+	all=$(git rev-list --all | awk '/^commit/ {print $NF}')
 else
-	all=`git log -n $range | awk '/^commit/ {print $NF}'`
+	all=$(git log -n $range | awk '/^commit/ {print $NF}')
 fi
 
-commit=`for i in $all; do
+commit=$(for i in $all; do
 	echo -n "$i "
 	# why is there no git diff --shortnumstat ?
 	git diff -M $spec $i | wc -l
-done | sort -k 2 -n | head -n 1 | cut -f 1 -d ' '`
+done | sort -k 2 -n | head -n 1 | cut -f 1 -d ' ')
 if [ "$mode" = diff ]; then
 	git log --no-walk $commit | cat -
 	git diff -M $spec $commit | cat -

--- a/git-filemerge
+++ b/git-filemerge
@@ -1,22 +1,22 @@
 #!/bin/sh
 if test $# = 0; then
-OLD=`git write-tree`
+OLD=$(git write-tree)
 elif test "$1" = --cached; then
 OLD=HEAD
-  NEW=`git write-tree`
+  NEW=$(git write-tree)
   shift
 fi
 if test $# -gt 0; then
 OLD="$1"; shift
 fi
 test $# -gt 0 && test -z "$CACHED" && NEW="$1"
-TMPDIR1=`mktemp -d`
+TMPDIR1=$(mktemp -d)
 git archive --format=tar $OLD | (cd $TMPDIR1; tar xf -)
 if test -z "$NEW"; then
 TMPDIR2=$(git rev-parse --show-cdup)
 test -z "$cdup" && TMPDIR2=.
 else
-TMPDIR2=`mktemp -d`
+TMPDIR2=$(mktemp -d)
   git archive --format=tar $NEW | (cd $TMPDIR2; tar xf -)
 fi
 

--- a/git-find-useful-dangling-trees
+++ b/git-find-useful-dangling-trees
@@ -1,7 +1,7 @@
 #!/bin/bash
 depth={1:-all} # 'all' or number of depth
 
-for i in $(git fsck --unreachable | egrep 'tree|commit' | cut -d\  -f3)
+for i in $(git fsck --unreachable | grep -E 'tree|commit' | cut -d\  -f3)
 do
 	echo -n "U:$i CM:"
 	git-closest-match $i num $depth

--- a/git-ignore-wizard
+++ b/git-ignore-wizard
@@ -12,20 +12,20 @@ then
 	exit 2
 fi
 
-type=`echo \
+type=$(echo \
 ".gitignore-root    # files all developers of this repo will want to exclude, in one central location
 .gitignore-dirname # same, but ignore file in parent directory, so you can have multiple .gitignore files
 exclude            # specific to it's repo, but irrelevant to other devs
 .gitconfig         # patterns you want to ignore, independent of the repository
-" | dmenu | cut -d ' ' -f1`
+" | dmenu | cut -d ' ' -f1)
 
 [ -z "$type" ] && echo 'Cancelled' && exit 0
 
-dirname=` dirname  $file`
-basename=`basename $file`
+dirname=$( dirname  $file)
+basename=$(basename $file)
 case $type in
 	.gitignore-root)
-		root=`git root $file` || exit 2
+		root=$(git root $file) || exit 2
 		dirname=$(readlink -f $dirname)
 		relative_dir=$(echo $dirname | sed "s#^$root##") # ie: /src
 		echo "$relative_dir/$basename" >> $root/.gitignore
@@ -35,7 +35,7 @@ case $type in
 		echo "$basename" >> $dirname/.gitignore
 		;;
 	exclude)
-		root=`git root $file` || exit 2
+		root=$(git root $file) || exit 2
 		dirname=$(readlink -f $dirname)
 		relative_dir=$(echo $dirname | sed "s#^$root##")
 		echo "$relative_dir/$basename" >> $root/info/exclude

--- a/git-interactive-merge
+++ b/git-interactive-merge
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -z "$1" -o -z "$2" ]
+if [ -z "$1" ] || [ -z "$2" ]
 then
 	echo "usage: $0 <from> <to>" >&2
 	exit 2

--- a/git-merge-to
+++ b/git-merge-to
@@ -11,6 +11,6 @@ else
 fi
 
 # get  current branch - typically master or develop
-cb=`git rev-parse --abbrev-ref HEAD`
+cb=$(git rev-parse --abbrev-ref HEAD)
 # no fast forward merge from current branch to destination branch
 git checkout $DST_BRANCH && git merge --ff $cb && git co $cb

--- a/git-release
+++ b/git-release
@@ -11,6 +11,6 @@ else
 fi
 
 # get  current branch - typically master or develop
-cb=`git rev-parse --abbrev-ref HEAD`
+cb=$(git rev-parse --abbrev-ref HEAD)
 # push current branch, pull destination branch, fast forward merge from current branch to destination branch, push and return
 git push && git checkout $DST_BRANCH && git pull && git merge --ff $cb && git push && git checkout $cb

--- a/git-remote-in-sync.sh
+++ b/git-remote-in-sync.sh
@@ -13,10 +13,10 @@
 # written by Dieter Plaetinck
 
 list="$@"
-[ -z "$list" ] && list=`git remote`
+[ -z "$list" ] && list=$(git remote)
 ret=0
 
-if [ -z "`git branch`" ]
+if [ -z "$(git branch)" ]
 then
 	if [ $(cd $(git root) && ls -Al | egrep -v "^(.git|total)" | wc -l) -gt 0 ]
 	then
@@ -42,7 +42,7 @@ else
 	if [ -n "$@" ]
 	then
 		echo "INFO: working with remote(s): $@"
-		echo "INFO: fyi, all remotes: "`git remote`
+		echo "INFO: fyi, all remotes: "$(git remote)
 	else
 		echo "INFO: working with all remotes: $list"
 	fi
@@ -64,7 +64,7 @@ do
 	fi
 	IFS_BACKUP=$IFS
 	IFS=$'\n'
-	for branch in `git branch`
+	for branch in $(git branch)
 	do
 		branch=${branch/\*/};
 		branch_local=${branch// /}; # git branch prefixes branches with spaces. and spaces in branchnames are illegal.
@@ -86,27 +86,27 @@ do
 	IFS=$IFS_BACKUP
 
 	# Check tags
-	out=`git push --tags -n $remote 2>&1`
+	out=$(git push --tags -n $remote 2>&1)
 	if [ "$out" != 'Everything up-to-date' ];
 	then
 		echo -e "  WARN: Some tags are not in $remote!\n$out" >&2
 		ret=1
 	else
-		echo "  INFO: All tags ("`git tag`") exist at $remote as well"
+		echo "  INFO: All tags ("$(git tag)") exist at $remote as well"
 	fi
 done
 
 # Check WC/index
-cur_branch=`git branch | grep '^\* ' | cut -d ' ' -f2`
+cur_branch=$(git branch | grep '^\* ' | cut -d ' ' -f2)
 cur_branch=${cur_branch// /}
 exp="# On branch $cur_branch
 nothing to commit (working directory clean)"
-out=`git status`
+out=$(git status)
 wc_ok=1
 if [ "$out" != "$exp" ]
 then
 	# usually i'd use bash regex, but this case is multiple-lines so bash regex is no go
-	out=$(echo "$out" | egrep -v "^(# On branch $cur_branch|# Your branch is behind .* commits, and can be fast-forwarded.|#|nothing to commit \(working directory clean\))$")
+	out=$(echo "$out" | grep -E -v "^(# On branch $cur_branch|# Your branch is behind .* commits, and can be fast-forwarded.|#|nothing to commit \(working directory clean\))$")
 	if [ -n "$out" ]
 	then
 		wc_ok=0
@@ -122,7 +122,7 @@ then
 fi
 
 # Check stash
-if [ `git stash list | wc -l` -gt 0 ];
+if [ $(git stash list | wc -l) -gt 0 ];
 then
 	echo "WARN: Dirty stash:" >&2
 	GIT_PAGER= git stash list >&2

--- a/git-root
+++ b/git-root
@@ -8,7 +8,7 @@ then
 	then
 		cd $1
 	else
-		cd `dirname $1`
+		cd $(dirname $1)
 	fi
 fi
 exec git rev-parse --show-toplevel

--- a/git-standup
+++ b/git-standup
@@ -36,7 +36,7 @@ fi
 # which may fail on systems lacking tput or terminfo
 set -e
 
-AUTHOR=${1:-"`git config user.name`"}
+AUTHOR=${1:-"$(git config user.name)"}
 
 WEEKSTART="$( cut -d '-' -f 1 <<< "$2" )";
 WEEKSTART=${WEEKSTART:="Mon"}

--- a/git-write-stream-info
+++ b/git-write-stream-info
@@ -30,7 +30,7 @@ else
 	to=$2
 fi
 
-file_name=`echo $from | sed 's/\//_/g'`--`echo $to | sed 's/\//_/g'`---$date
+file_name=$(echo $from | sed 's/\//_/g'`--`echo $to | sed 's/\//_/g')---$date
 file=$where/$file_name
 last=$where/last
 


### PR DESCRIPTION
Fixes deprecations in which there is an easy and corerct fix. They include:

- `egrep` is deprecated in favor of `grep -E` (it's deprecated upstream; some distributions don't show it)
- `` is deprecated for `$()`
- `-o` is deprecated for `||` (creating a separate `[` context)
- `which` is deprecated in Debian, with `command -v` used as a general replacement