### PR TITLE
chore: Fix POSIX shell syntax errors

### DIFF
--- a/git-apply-url
+++ b/git-apply-url
@@ -31,12 +31,12 @@
 
 URL=$1
 
-function error {
+error() {
   echo $*
   exit 1
 }
 
-if [[ ! $URL ]]; then
+if [ ! $URL ]; then
   error $0 URL
 fi
 

--- a/git-closest-match
+++ b/git-closest-match
@@ -12,7 +12,7 @@ else
 fi
 
 commit=`for i in $all; do
-	echo -n "$i "
+	printf '%s\n' "$i "
 	# why is there no git diff --shortnumstat ?
 	git diff -M $spec $i | wc -l
 done | sort -k 2 -n | head -n 1 | cut -f 1 -d ' '`
@@ -20,6 +20,6 @@ if [ "$mode" = diff ]; then
 	git log --no-walk $commit | cat -
 	git diff -M $spec $commit | cat -
 else
-	echo -n "$commit: "
+	printf '%s\n' "$commit: "
 	 git diff -M $spec $commit | wc -l
 fi

--- a/git-find-children
+++ b/git-find-children
@@ -7,5 +7,6 @@ fi
 for ref in "$@"; do
     for sha1 in $(git rev-list "$@")
     do
+        :
     done
 done

--- a/git-save-home
+++ b/git-save-home
@@ -15,7 +15,7 @@
 
 MODIFIED=$(git status | grep modified | cut -d " " -f 3-)
 
-if [ "x$MODIFIED" == x ]; then
+if [ -n "$MODIFIED" ]; then
   echo no changes
 else
   git add -f $MODIFIED \


### PR DESCRIPTION
On files marked as being interpreted with `sh`, some aren't complient in some ways. They include:

- Using `function`; this isn't specified by POSIX, so functions that do this were changed to a compliant declaration
- `echo -n` isn't specified by POSIX; it was placed with a compliant `printf` alternative
- `==` in `[` is not supported by POSIX. It was replaced with `=` (and now uses a more semantic comparison)
- Loops like the `for ... do` must contain at least one command; the `:` builtin was used for now to prevent parsing errors.