### PR TITLE
chore: Fix miscellaneous bugs

### DIFF
--- a/git-find-useful-dangling-trees
+++ b/git-find-useful-dangling-trees
@@ -1,5 +1,5 @@
 #!/bin/bash
-depth={1:-all} # 'all' or number of depth
+depth=${1:-all} # 'all' or number of depth
 
 for i in $(git fsck --unreachable | egrep 'tree|commit' | cut -d\  -f3)
 do

--- a/git-fire-subtree/git-fire
+++ b/git-fire-subtree/git-fire
@@ -71,7 +71,6 @@ display_help() {
     -h, --help                      Display this help information
 
 EOF
-	exit 0
 }
 
 


### PR DESCRIPTION
These fix some bugs I came across while working on #44 and #45 

- The first fix ensures the brace expansion context is actually created, which was the original intention
- The second one removes an extraneous `exit 0` 