### PR TITLE
chore: Improve path quoting

### DIFF
--- a/git-clone.sh
+++ b/git-clone.sh
@@ -19,7 +19,7 @@ function clone {
   $GIT clone -q $1 $2
   res=$?
   
-  cd $2
+  cd "$2"
   
   $GIT pull --all
   
@@ -29,4 +29,4 @@ function clone {
 }
 
 echo "cloning repository into ... $2"
-clone $1 $2
+clone $1 "$2"

--- a/git-filemerge
+++ b/git-filemerge
@@ -11,16 +11,16 @@ OLD="$1"; shift
 fi
 test $# -gt 0 && test -z "$CACHED" && NEW="$1"
 TMPDIR1=`mktemp -d`
-git archive --format=tar $OLD | (cd $TMPDIR1; tar xf -)
+git archive --format=tar $OLD | (cd "$TMPDIR1"; tar xf -)
 if test -z "$NEW"; then
 TMPDIR2=$(git rev-parse --show-cdup)
 test -z "$cdup" && TMPDIR2=.
 else
 TMPDIR2=`mktemp -d`
-  git archive --format=tar $NEW | (cd $TMPDIR2; tar xf -)
+  git archive --format=tar $NEW | (cd "$TMPDIR2"; tar xf -)
 fi
 
-opendiff $TMPDIR1 $TMPDIR2 | cat
-rm -rf $TMPDIR1
-test ! -z "$NEW" && rm -rf $TMPDIR2
+opendiff "$TMPDIR1" "$TMPDIR2" | cat
+rm -rf "$TMPDIR1"
+test ! -z "$NEW" && rm -rf "$TMPDIR2"
 

--- a/git-remote-in-sync.sh
+++ b/git-remote-in-sync.sh
@@ -18,10 +18,10 @@ ret=0
 
 if [ -z "`git branch`" ]
 then
-	if [ $(cd $(git root) && ls -Al | egrep -v "^(.git|total)" | wc -l) -gt 0 ]
+	if [ $(cd "$(git root)" && ls -Al | egrep -v "^(.git|total)" | wc -l) -gt 0 ]
 	then
 		echo "WARN: This repo doesn't contain any branch, but contains a bunch of files!" >&2
-		ls -Alh $(git root)
+		ls -Alh "$(git root)"
 		ret=1
 	else
 		echo "INFO: This repo doesn't contain any branch, and is empty"

--- a/git-root
+++ b/git-root
@@ -6,9 +6,9 @@ if [ -n "$1" ]
 then
 	if [ -d "$1" ]
 	then
-		cd $1
+		cd "$1"
 	else
-		cd `dirname $1`
+		cd "`dirname $1`"
 	fi
 fi
 exec git rev-parse --show-toplevel

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -12,22 +12,22 @@ MIRROR=$HOME/Products/ledger-pre-commit-mirror
 set -e
 
 # Checkout a copy of the current index into MIRROR
-git checkout-index --prefix=$MIRROR/ -af
+git checkout-index --prefix="$MIRROR/" -af
 
 # Remove files from MIRROR which are no longer present in the index
 git diff-index --cached --name-only --diff-filter=D -z HEAD | \
-    (cd $MIRROR && xargs -0 rm -f --)
+    (cd "$MIRROR" && xargs -0 rm -f --)
 
 # Copy only _changed files_ from MIRROR to TMPDIR, without copying timestamps.
 # This includes copying over new files, and deleting removed ones.  This way,
 # "make check" will only rebuild what is necessary to validate the commit.
-rsync -rlpgoDOc --delete --exclude-from=tools/excludes $MIRROR/ $TMPDIR/
+rsync -rlpgoDOc --delete --exclude-from=tools/excludes "$MIRROR/" "$TMPDIR/"
 
 # Everything else happens in the temporary build tree
-if [ ! -f $TMPDIR/lib/utfcpp/source/utf8.h ]; then
-    rsync -a --delete lib/utfcpp/ $TMPDIR/lib/utfcpp/
+if [ ! -f "$TMPDIR/lib/utfcpp/source/utf8.h" ]; then
+    rsync -a --delete lib/utfcpp/ "$TMPDIR/lib/utfcpp/"
 fi
-cd $TMPDIR
+cd "$TMPDIR"
 
 # Make sure there is a current Makefile.  Regeneration of Makefile happens
 # automatically, but if myacprep or acprep changes, we want to regenerate


### PR DESCRIPTION
This improves quoting where I think it matters the most: path handling. With these patches, the scripts simply work in more places in which the path to the current directory contains any kind of whitespace, including spaces.

It doesn't fix all situations - in some locations like `git-each` and `git-sync`, this whitespace splitting behavior is relied upon to enable performing operating on multiple directories. Fixing those requries slightly separate patches.