### PR TITLE
Improved shebangs

### DIFF
--- a/git-addsub
+++ b/git-addsub
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script makes it much easier to add new submodules
 

--- a/git-addtree
+++ b/git-addtree
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git subtree add --prefix $1 ext/$(basename $1) master --squash

--- a/git-all-objects
+++ b/git-all-objects
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 shopt -s nullglob extglob
 

--- a/git-already-merged
+++ b/git-already-merged
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # From https://railsware.com/blog/git-housekeeping-tutorial-clean-up-outdated-branches-in-local-and-remote-repositories/
 

--- a/git-archive-all
+++ b/git-archive-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Super basic tool to export repo and all submodules
 # as a single zip file

--- a/git-branch-done
+++ b/git-branch-done
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git branch-done <branch>
 
 # destination branch as parameter - depends on merge strategy, typically master

--- a/git-build
+++ b/git-build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 git clean -f -x -d
 git checkout $1

--- a/git-changebar
+++ b/git-changebar
@@ -1,4 +1,4 @@
-#!/bin/sh --
+#!/bin/sh
 #
 # git-changebar
 #

--- a/git-children-of
+++ b/git-children-of
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 commit=$1
 branch=$2

--- a/git-clone.sh
+++ b/git-clone.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # this script clones a repository, including all its remote branches
 # Author: julianromera

--- a/git-clone.sh
+++ b/git-clone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this script clones a repository, including all its remote branches
 # Author: julianromera

--- a/git-cmpdir
+++ b/git-cmpdir
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 stat=false
 if [[ "$1" == "--stat" ]]; then

--- a/git-current
+++ b/git-current
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -z "$1" ]]; then
     ancestor=master

--- a/git-current-branch
+++ b/git-current-branch
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git rev-parse --abbrev-ref HEAD

--- a/git-diff-directory
+++ b/git-diff-directory
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 stat=true
 if [[ "$1" == "-p" ]]; then

--- a/git-discover-large-blobs
+++ b/git-discover-large-blobs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -x 
 
 # Shows you the largest objects in your repo's pack file.

--- a/git-each
+++ b/git-each
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIRS="."

--- a/git-each
+++ b/git-each
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 
 DIRS="."
 if [[ "$1" == --dir ]]; then

--- a/git-every
+++ b/git-every
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec find . -name .git -type d -exec git --git-dir="{}" "$@" \;

--- a/git-fetch-github
+++ b/git-fetch-github
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 REMOTE=${1:-origin}
 git config remote.${REMOTE}.fetch "+refs/pull/*:refs/remotes/${REMOTE}/pr/*"

--- a/git-find-children
+++ b/git-find-children
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $# == 0 ]]; then
     echo usage: git find-children REFS...

--- a/git-find-fetch
+++ b/git-find-fetch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # usage: git-find-fetch [--mirror] [--repack] DIRS...
 #

--- a/git-find-useful-dangling-trees
+++ b/git-find-useful-dangling-trees
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 depth=${1:-all} # 'all' or number of depth
 
 for i in $(git fsck --unreachable | egrep 'tree|commit' | cut -d\  -f3)

--- a/git-fix-wt
+++ b/git-fix-wt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 find . -name config -type f -print0 \
     | xargs -0 perl -i -ne 'print unless /worktree =/;'

--- a/git-fixws
+++ b/git-fixws
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # If you are using MacPorts, you'll need to install 'patchutils'
 

--- a/git-hunt-and-seek
+++ b/git-hunt-and-seek
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for hash in $(grep ^commit | awk '{print $2}'); do
     git diff-directory $1 $hash

--- a/git-ignore-wizard
+++ b/git-ignore-wizard
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # take a file/directory as arg1, to be added to ignore rules.
 # the user selects which ignore rules using dmenu
 # in the .gitconfig case, we should probably allow the user to edit it,

--- a/git-interactive-merge
+++ b/git-interactive-merge
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -z "$1" -o -z "$2" ]
 then
 	echo "usage: $0 <from> <to>" >&2

--- a/git-link-upstream
+++ b/git-link-upstream
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BRANCH=$(git-current-branch)
 

--- a/git-master
+++ b/git-master
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git stash
 git co master
 git stash pop

--- a/git-merge-to
+++ b/git-merge-to
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git merge-to <branch>
 
 # destination branch as parameter - depends on merge strategy, typically release

--- a/git-publish
+++ b/git-publish
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SERVER=$1
 PATHNAME=$2

--- a/git-pulltree
+++ b/git-pulltree
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git subtree pull --prefix $1 ext/$(basename $1) master --squash

--- a/git-pushtree
+++ b/git-pushtree
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git subtree push --prefix $1 fork/$(basename $1) master

--- a/git-rebase-master
+++ b/git-rebase-master
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-
+#!/bin/bash
+set -e
 git checkout master
 git pull --ff-only
 git checkout -

--- a/git-rebase-master
+++ b/git-rebase-master
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 git checkout master
 git pull --ff-only

--- a/git-rebranch
+++ b/git-rebranch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 newbranch=$1
 remote=${2:-origin/master}

--- a/git-rebranch
+++ b/git-rebranch
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-
+#!/bin/bash
+set -e
 newbranch=$1
 remote=${2:-origin/master}
 

--- a/git-release
+++ b/git-release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git release <branch>
 
 # destination branch as parameter - depends on merge strategy, typically release

--- a/git-remote-in-sync.sh
+++ b/git-remote-in-sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # checks if the specified remote(s) are in sync with what we have
 # in other words: do we have anything which is not at the remote?
 # Any commit, tag, branch, dirty WC/index or stashed state?

--- a/git-remove-empty-commits
+++ b/git-remove-empty-commits
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 git filter-branch --commit-filter 'if [ z$1 = z`git rev-parse $3^{tree}` ]; then skip_commit "$@"; else git commit-tree "$@"; fi' "$@"

--- a/git-rm-conflicts
+++ b/git-rm-conflicts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # git-rm-conflicts, version 1.3
 #

--- a/git-root
+++ b/git-root
@@ -1,7 +1,8 @@
-#!/bin/sh -e
+#!/bin/sh
 # inspired by http://stackoverflow.com/questions/957928/is-there-a-way-to-get-to-the-git-root-directory-in-one-command/3009378#3009378
 # gives absolute path to git repository root, either for cwd, or directory (or files' dirname) given as $1
 # when not a git repository, exit >0
+set -e
 if [ -n "$1" ]
 then
 	if [ -d "$1" ]

--- a/git-save
+++ b/git-save
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # To be used with the git-save-* scripts @ https://github.com/jwiegley/git-scripts
 mypath=$(dirname $0)

--- a/git-signed-tag
+++ b/git-signed-tag
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 git tag -s -m "$1" $1 $2

--- a/git-smerge
+++ b/git-smerge
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 current=$(git symbolic-ref HEAD | sed 's%refs/heads/%%')
 branch=$1

--- a/git-stale-branches
+++ b/git-stale-branches
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! git config --get-all remote.origin.fetch | grep -q '/pr/'; then
     git config --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pr/*'

--- a/git-sync
+++ b/git-sync
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIRS="$@"
 if [[ -z "$DIRS" ]]; then

--- a/git-tag-diff
+++ b/git-tag-diff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Show the differences between local tags and ones on the remote, if any
 # (defaults to origin, but another remote may be specified on the commandline)
 

--- a/git-touch-repos
+++ b/git-touch-repos
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export GIT_DIR
 

--- a/git-trial-merge
+++ b/git-trial-merge
@@ -1,3 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh
+set -xe
 git checkout --detach HEAD
 git merge --no-edit -- "$@"

--- a/git-undo
+++ b/git-undo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cmd=$1
 shift 1

--- a/git-working-tree
+++ b/git-working-tree
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set contents of the working tree equal to TREEISH
 


### PR DESCRIPTION
The first commit:
- Remove Bash arguments to shebangs (to ensure the `set` options are always set on every possible invocation (such as `bash ...`))
- Fix case in which shebang is invalid (`git-clone`)

The second commit:
- Uses `#!/usr/bin/env/bash` for Bash shebang instead of `#!/bin/bash` since the latter doesn't work on some environments, such as NixOS (apparently it isn't specified by POSIX?) 