### PR TITLE
chore: Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rb]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
While working on #48 and #44, I noticed that some files like `git-branch-done`, `git-merge-to` and others don't end in a newline. As a result, strictly speaking, that last "line" will be not considered a part of the text file, according to POSIX.

To fix this, I propose adding an [EditorConfig](https://editorconfig.org) file. When editors read this (some require a plugin like VSCode) file, it adjusts the formatting based on the rules. One thing to note is that rules that specify whitespace are only take effect to each inserted text. For example, with `indent_style = space`, when editing a file that predominately uses tabs, only the spaces will be inserted on each `<tab>` - other characters are not modified.
