### PR TITLE
chore: Improve Bash hygiene 

### DIFF
--- a/git-closest-match
+++ b/git-closest-match
@@ -8,18 +8,18 @@ range=${3:-30} # 'all' or most recent <num> in current branch?. 'all' can be qui
 if [ "$range" = 'all' ]; then
 	all=$(git rev-list --all | awk '/^commit/ {print $NF}')
 else
-	all=$(git log -n $range | awk '/^commit/ {print $NF}')
+	all=$(git log -n "$range" | awk '/^commit/ {print $NF}')
 fi
 
 commit=$(for i in $all; do
 	printf '%s\n' "$i "
 	# why is there no git diff --shortnumstat ?
-	git diff -M $spec $i | wc -l
+	git diff -M "$spec" $i | wc -l
 done | sort -k 2 -n | head -n 1 | cut -f 1 -d ' ')
 if [ "$mode" = diff ]; then
-	git log --no-walk $commit | cat -
-	git diff -M $spec $commit | cat -
+	git log --no-walk "$commit" | cat -
+	git diff -M "$spec" "$commit" | cat -
 else
 	printf '%s\n' "$commit: "
-	 git diff -M $spec $commit | wc -l
+	 git diff -M "$spec" "$commit" | wc -l
 fi

--- a/git-cmpdir
+++ b/git-cmpdir
@@ -6,7 +6,7 @@ if [[ "$1" == "--stat" ]]; then
     shift 1
 fi
 
-git checkout $1
+git checkout "$1"
 sync
 echo ----------------------------------------------------------------------
 

--- a/git-contr
+++ b/git-contr
@@ -2,5 +2,5 @@
 
 filePath=$1
 
-git blame --line-porcelain -C $filePath | sed -n 's/^author //p' |
+git blame --line-porcelain -C "$filePath" | sed -n 's/^author //p' |
 sort | uniq -c | sort -rn

--- a/git-current
+++ b/git-current
@@ -8,14 +8,14 @@ else
 fi
 current="$ancestor"
 
-ancestor=$(git rev-parse $ancestor)
+ancestor=$(git rev-parse "$ancestor")
 
 for head in $(git rev-parse --branches); do
-    if [[ $head != $ancestor ]]; then
-	if git rev-list -30 $head | grep -q $ancestor; then
-	    current="$current $(git describe --all --abbrev=0 $head | sed 's/heads\///')"
-	fi
+    if [[ $head != "$ancestor" ]]; then
+        if git rev-list -30 "$head" | grep -q "$ancestor"; then
+            current="$current $(git describe --all --abbrev=0 "$head" | sed 's/heads\///')"
+        fi
     fi
 done
 
-git show-branch $current
+git show-branch "$current"

--- a/git-delete-branch
+++ b/git-delete-branch
@@ -1,4 +1,4 @@
 #!/bin/sh
 # remove remote git branch
 
-git branch -D $1 && git push origin :$1
+git branch -D "$1" && git push origin ":$1"

--- a/git-delete-tag
+++ b/git-delete-tag
@@ -1,5 +1,5 @@
 #!/bin/sh
 # remove remote git tag
 
-git tag -d $1
-git push origin :refs/tags/$1
+git tag -d "$1"
+git push origin ":refs/tags/$1"

--- a/git-diff-directory
+++ b/git-diff-directory
@@ -8,7 +8,7 @@ fi
 
 HERE=$(pwd)
 
-(cd "$1" && git --git-dir=$HERE/.git diff ${2:-HEAD}) | \
+(cd "$1" && git --git-dir="$HERE/.git" diff "${2:-HEAD}") | \
     if [[ $stat == true ]]; then \
         diffstat | grep -v only$; \
     else \

--- a/git-discover-large-blobs
+++ b/git-discover-large-blobs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#set -x 
+#set -x
 
 # Shows you the largest objects in your repo's pack file.
 #
@@ -18,9 +18,9 @@
 IFS=$'\n';
 
 # find top-level dir of a non-bare repo
-_GIT_DIR=`git rev-parse --show-toplevel` || exit 1
+_GIT_DIR=$(git rev-parse --show-toplevel) || exit 1
 
-if [ -n ${_GIT_DIR} ] && [ -d ${_GIT_DIR}/.git/objects/pack ]; then
+if [ -n "${_GIT_DIR}" ] && [ -d "${_GIT_DIR}"/.git/objects/pack ]; then
 	PACK_DIR=${_GIT_DIR}/.git/objects/pack
 elif [ -d ./objects/pack ]; then
 	# bare repo
@@ -29,9 +29,9 @@ else
 	echo "Cannot locate pack directory"
 	exit 1
 fi
-	
+
 # list all objects including their size, sort by size, take top 10
-objects=`git verify-pack -v ${PACK_DIR}/pack-*.idx | grep -v chain | sort -k3nr | head`
+objects=$(git verify-pack -v "${PACK_DIR}"/pack-*.idx | grep -v chain | sort -k3nr | head)
 
 echo "All sizes are in kB's. The pack column is the size of the object, compressed, inside the pack file."
 
@@ -39,15 +39,15 @@ output="size,pack,SHA,location"
 for y in $objects
 do
 	# extract the size in bytes
-	size=$((`echo $y | cut -f 5 -d ' '`/1024))
+	size=$(($(echo $y | cut -f 5 -d ' ')/1024))
 	# extract the compressed size in bytes
-	compressedSize=$((`echo $y | cut -f 6 -d ' '`/1024))
+	compressedSize=$(($(echo $y | cut -f 6 -d ' ')/1024))
 	# extract the SHA
-	sha=`echo $y | cut -f 1 -d ' '`
+	sha=$(echo $y | cut -f 1 -d ' ')
 	# find the objects location in the repository tree
-	other=`git rev-list --all --objects | grep $sha`
+	other=$(git rev-list --all --objects | grep "$sha")
 	#lineBreak=`echo -e "\n"`
 	output="${output}\n${size},${compressedSize},${other}"
 done
 
-echo -e $output | column -t -s ', '
+echo -e "$output" | column -t -s ', '

--- a/git-empty-branch
+++ b/git-empty-branch
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 git stash
-git symbolic-ref HEAD refs/heads/$1
+git symbolic-ref HEAD "refs/heads/$1"
 rm .git/index
 git clean -f -d

--- a/git-fat-objects
+++ b/git-fat-objects
@@ -6,7 +6,7 @@ git rev-list --all --objects | \
     grep blob | \
     sort -n -k 3 | \
     tail -n40 | \
-    while read hash type size; do
+    while read -r hash type size; do
          echo -n "-e s/$hash/$size/p ";
     done) | \
     sort -n -k1

--- a/git-fetch-github
+++ b/git-fetch-github
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 REMOTE=${1:-origin}
-git config remote.${REMOTE}.fetch "+refs/pull/*:refs/remotes/${REMOTE}/pr/*"
+git config "remote.${REMOTE}.fetch" "+refs/pull/*:refs/remotes/${REMOTE}/pr/*"

--- a/git-filemerge
+++ b/git-filemerge
@@ -14,7 +14,7 @@ TMPDIR1=$(mktemp -d)
 git archive --format=tar $OLD | (cd "$TMPDIR1"; tar xf -)
 if test -z "$NEW"; then
 TMPDIR2=$(git rev-parse --show-cdup)
-test -z "$cdup" && TMPDIR2=.
+test -z "$TMPDIR2" && TMPDIR2=.
 else
 TMPDIR2=$(mktemp -d)
   git archive --format=tar $NEW | (cd "$TMPDIR2"; tar xf -)

--- a/git-find-blob
+++ b/git-find-blob
@@ -4,10 +4,10 @@ filename=$1
 
 want=$(git hash-object "$filename")
 
-git rev-list --since="6 months ago" HEAD | while read commit ; do
-    git ls-tree -r $commit | while read perm type hash filename; do
+git rev-list --since="6 months ago" HEAD | while read -r commit ; do
+    git ls-tree -r "$commit" | while read -r perm type hash filename; do
         if test "$want" = "$hash"; then
-            echo matched $filename in commit $commit
+            echo "matched $filename in commit $commit"
         fi
     done
 done

--- a/git-find-useful-dangling-trees
+++ b/git-find-useful-dangling-trees
@@ -4,5 +4,5 @@ depth=${1:-all} # 'all' or number of depth
 for i in $(git fsck --unreachable | grep -E 'tree|commit' | cut -d\  -f3)
 do
 	echo -n "U:$i CM:"
-	git-closest-match $i num $depth
+	git-closest-match "$i" num "$depth"
 done

--- a/git-flush
+++ b/git-flush
@@ -4,8 +4,8 @@
 # as possible, by dropping all reflogs, stashes, and other cruft that may
 # be bloating your pack files.
 
-/bin/rm -fr .git/refs/original
-/bin/rm -fr .git/refs/snapshots
+rm -fr .git/refs/original
+rm -fr .git/refs/snapshots
 
 if [ -f .git/info/refs ]; then
     perl -i -ne 'print unless /refs\/original/;' .git/info/refs

--- a/git-follow
+++ b/git-follow
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-CURRENT=$(basename $(pwd))
+CURRENT=$(basename "$(pwd)")
 
-git remote add -t master -f $1 git://github.com/$1/$CURRENT.git
+git remote add -t master -f "$1" "git://github.com/$1/$CURRENT.git"

--- a/git-hunt-and-seek
+++ b/git-hunt-and-seek
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 for hash in $(grep ^commit | awk '{print $2}'); do
-    git diff-directory $1 $hash
+    git diff-directory "$1" "$hash"
 done

--- a/git-ignore-wizard
+++ b/git-ignore-wizard
@@ -6,7 +6,7 @@
 # basename
 
 file=$1
-if [ -z "$file" -o ! -e "$file" ]
+if [[ -z "$file" || ! -e "$file" ]]
 then
 	echo 'No such file or directory' >&2
 	exit 2
@@ -21,24 +21,24 @@ exclude            # specific to it's repo, but irrelevant to other devs
 
 [ -z "$type" ] && echo 'Cancelled' && exit 0
 
-dirname=$( dirname  $file)
-basename=$(basename $file)
+dirname=$( dirname  "$file")
+basename=$(basename "$file")
 case $type in
 	.gitignore-root)
-		root=$(git root $file) || exit 2
-		dirname=$(readlink -f $dirname)
-		relative_dir=$(echo $dirname | sed "s#^$root##") # ie: /src
-		echo "$relative_dir/$basename" >> $root/.gitignore
+		root=$(git root "$file") || exit 2
+		dirname=$(readlink -f "$dirname")
+		relative_dir=$(echo "$dirname" | sed "s#^$root##") # ie: /src
+		echo "$relative_dir/$basename" >> "$root/.gitignore"
 		;;
 	.gitignore-dirname)
-		git root $file >/dev/null || exit 2
-		echo "$basename" >> $dirname/.gitignore
+		git root "$file ">/dev/null || exit 2
+		echo "$basename" >> "$dirname/.gitignore"
 		;;
 	exclude)
-		root=$(git root $file) || exit 2
-		dirname=$(readlink -f $dirname)
-		relative_dir=$(echo $dirname | sed "s#^$root##")
-		echo "$relative_dir/$basename" >> $root/info/exclude
+		root=$(git root "$file") || exit 2
+		dirname=$(readlink -f "$dirname")
+		relative_dir=$(echo "$dirname" | sed "s#^$root##")
+		echo "$relative_dir/$basename" >> "$root/info/exclude"
 		;;
 	.gitconfig)
 		#TODO. git config --get-all ?, then another dmenu? how many such config keys are allowed?

--- a/git-igunk
+++ b/git-igunk
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-git ls-files --other --exclude-standard | while read path; do
+git ls-files --other --exclude-standard | while read -r path; do
     echo "/$path" >> .gitignore
 done

--- a/git-interactive-merge
+++ b/git-interactive-merge
@@ -6,10 +6,10 @@ then
 fi
 from=$1
 to=$2
-git checkout $from
-git checkout -b ${from}_tmp
+git checkout "$from"
+git checkout -b "${from}_tmp"
 # drops you in an editor, pick the changes you want
-git rebase -i $to
-git checkout $to
-git pull . ${from}_tmp
-git branch -d ${from}_tmp
+git rebase -i "$to"
+git checkout "$to"
+git pull . "${from}_tmp"
+git branch -d "${from}_tmp"


### PR DESCRIPTION
Some notable changes

- fixes a bug in `git-discover-large-blobs:23`, the first `if [ -z ...` conditional now works as intended since the variable is quoted
- fixes a bug in in `git-filemerge`, in which an uninitialized variable `cdup` was used (`TMPDIR2` seemed to be the intended variable)
- in `git-flush`, `/bin/rm` was replaced in favor of `rm`, a potentially breaking change, but for all practical purposes, shouldn't be a problem.